### PR TITLE
Set grpc-swift version to 2.0.0-alpha.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    branch: "main"
+    exact: "2.0.0-alpha.1"
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",


### PR DESCRIPTION
Motivation:

We just tagged grpc-swift 2.0.0-alpha.1, we should use it.

Modifications:

Update version requirement.

Result:

Better version management.