### PR TITLE
Add deployment targets to the package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,6 +97,13 @@ let targets: [Target] = [
 
 let package = Package(
   name: "grpc-swift-protobuf",
+  platforms: [
+    .macOS(.v15),
+    .iOS(.v18),
+    .tvOS(.v18),
+    .watchOS(.v11),
+    .visionOS(.v2),
+  ],
   products: products,
   dependencies: dependencies,
   targets: targets


### PR DESCRIPTION
Motivation:

Core components of grpc-swift v2 require API from the latest SDKs. This causes a proliferation of availability annotations through our API. Rather than doing this we can set the minimum platforms in the package manifest.

Modifications:

- Remove availability annotations
- Set platforms in the package manifest

Result:

- Less boilerplate
- Users must set platforms in their package manifest