### PR TITLE
Fix casing of generated services and methods

### DIFF
--- a/Sources/GRPCProtobufCodeGen/CamelCaser.swift
+++ b/Sources/GRPCProtobufCodeGen/CamelCaser.swift
@@ -26,7 +26,8 @@ package struct CamelCaser {
       return input
     } else if indexOfFirstLowercase == input.index(after: input.startIndex) {
       // The second character in `input` is lower case. As in: "ImportCSV".
-      return input[input.startIndex].lowercased() + input[indexOfFirstLowercase...]  // -> "importCSV"
+      // returns "importCSV"
+      return input[input.startIndex].lowercased() + input[indexOfFirstLowercase...]
     } else {
       // The first lower case character is further within `input`. Tentatively, `input` begins
       // with one or more abbreviations. Therefore, the last encountered upper case character
@@ -35,7 +36,8 @@ package struct CamelCaser {
       let leadingAbbreviation = input[..<input.index(before: indexOfFirstLowercase)]
       let followingWords = input[input.index(before: indexOfFirstLowercase)...]
 
-      return leadingAbbreviation.lowercased() + followingWords  // -> "foobarImportCSV"
+      // returns "foobarImportCSV"
+      return leadingAbbreviation.lowercased() + followingWords
     }
   }
 }

--- a/Sources/GRPCProtobufCodeGen/CamelCaser.swift
+++ b/Sources/GRPCProtobufCodeGen/CamelCaser.swift
@@ -16,31 +16,26 @@
 
 package struct CamelCaser {
   /// Converts a string from upper camel case to lower camel case.
-  package static func toLowerCamelCase(_ s: String) -> String {
-    if s.isEmpty { return "" }
+  package static func toLowerCamelCase(_ input: String) -> String {
+    guard let indexOfFirstLowercase = input.firstIndex(where: { $0.isLowercase }) else {
+      return input.lowercased()
+    }
 
-    let indexOfFirstLowerCase = s.firstIndex(where: { $0 != "_" && $0.lowercased() == String($0) })
-
-    if let indexOfFirstLowerCase {
-      if indexOfFirstLowerCase == s.startIndex {
-        // `s` already begins with a lower case letter. As in: "importCSV".
-        return s
-      } else if indexOfFirstLowerCase == s.index(after: s.startIndex) {
-        // The second character in `s` is lower case. As in: "ImportCSV".
-        return s[s.startIndex].lowercased() + s[indexOfFirstLowerCase...]  // -> "importCSV"
-      } else {
-        // The first lower case character is further within `s`. Tentatively, `s` begins with one or
-        // more abbreviations. Therefore, the last encountered upper case character could be the
-        // beginning of the next word. As in: "FOOBARImportCSV".
-
-        let leadingAbbreviation = s[..<s.index(before: indexOfFirstLowerCase)]
-        let followingWords = s[s.index(before: indexOfFirstLowerCase)...]
-
-        return leadingAbbreviation.lowercased() + followingWords  // -> "foobarImportCSV"
-      }
+    if indexOfFirstLowercase == input.startIndex {
+      // `input` already begins with a lower case letter. As in: "importCSV".
+      return input
+    } else if indexOfFirstLowercase == input.index(after: input.startIndex) {
+      // The second character in `input` is lower case. As in: "ImportCSV".
+      return input[input.startIndex].lowercased() + input[indexOfFirstLowercase...]  // -> "importCSV"
     } else {
-      // `s` did not contain any lower case letter.
-      return s.lowercased()
+      // The first lower case character is further within `input`. Tentatively, `input` begins
+      // with one or more abbreviations. Therefore, the last encountered upper case character
+      // could be the beginning of the next word. As in: "FOOBARImportCSV".
+
+      let leadingAbbreviation = input[..<input.index(before: indexOfFirstLowercase)]
+      let followingWords = input[input.index(before: indexOfFirstLowercase)...]
+
+      return leadingAbbreviation.lowercased() + followingWords  // -> "foobarImportCSV"
     }
   }
 }

--- a/Sources/GRPCProtobufCodeGen/CamelCaser.swift
+++ b/Sources/GRPCProtobufCodeGen/CamelCaser.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package struct CamelCaser {
+package enum CamelCaser {
   /// Converts a string from upper camel case to lower camel case.
   package static func toLowerCamelCase(_ input: String) -> String {
     guard let indexOfFirstLowercase = input.firstIndex(where: { $0.isLowercase }) else {

--- a/Sources/GRPCProtobufCodeGen/CamelCaser.swift
+++ b/Sources/GRPCProtobufCodeGen/CamelCaser.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package struct CamelCaser {
+  /// Converts a string from upper camel case to lower camel case.
+  package static func toLowerCamelCase(_ s: String) -> String {
+    if s.isEmpty { return "" }
+
+    let indexOfFirstLowerCase = s.firstIndex(where: { $0 != "_" && $0.lowercased() == String($0) })
+
+    if let indexOfFirstLowerCase {
+      if indexOfFirstLowerCase == s.startIndex {
+        // `s` already begins with a lower case letter. As in: "importCSV".
+        return s
+      } else if indexOfFirstLowerCase == s.index(after: s.startIndex) {
+        // The second character in `s` is lower case. As in: "ImportCSV".
+        return s[s.startIndex].lowercased() + s[indexOfFirstLowerCase...]  // -> "importCSV"
+      } else {
+        // The first lower case character is further within `s`. Tentatively, `s` begins with one or
+        // more abbreviations. Therefore, the last encountered upper case character could be the
+        // beginning of the next word. As in: "FOOBARImportCSV".
+
+        let leadingAbbreviation = s[..<s.index(before: indexOfFirstLowerCase)]
+        let followingWords = s[s.index(before: indexOfFirstLowerCase)...]
+
+        return leadingAbbreviation.lowercased() + followingWords  // -> "foobarImportCSV"
+      }
+    } else {
+      // `s` did not contain any lower case letter.
+      return s.lowercased()
+    }
+  }
+}

--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
@@ -15,7 +15,6 @@
  */
 
 internal import Foundation
-internal import SwiftProtobuf
 internal import SwiftProtobufPluginLibrary
 
 internal import struct GRPCCodeGen.CodeGenerationRequest
@@ -125,8 +124,8 @@ extension CodeGenerationRequest.ServiceDescriptor {
     }
     let name = CodeGenerationRequest.Name(
       base: descriptor.name,
-      generatedUpperCase: NamingUtils.toUpperCamelCase(descriptor.name),
-      generatedLowerCase: NamingUtils.toLowerCamelCase(descriptor.name)
+      generatedUpperCase: descriptor.name,  // The service name from the '.proto' file is expected to be in upper camel case
+      generatedLowerCase: CamelCaser.toLowerCamelCase(descriptor.name)
     )
 
     // Packages that are based on the path of the '.proto' file usually
@@ -145,8 +144,8 @@ extension CodeGenerationRequest.ServiceDescriptor.MethodDescriptor {
   fileprivate init(descriptor: MethodDescriptor, protobufNamer: SwiftProtobufNamer) {
     let name = CodeGenerationRequest.Name(
       base: descriptor.name,
-      generatedUpperCase: NamingUtils.toUpperCamelCase(descriptor.name),
-      generatedLowerCase: NamingUtils.toLowerCamelCase(descriptor.name)
+      generatedUpperCase: descriptor.name,  // The method name from the '.proto' file is expected to be in upper camel case
+      generatedLowerCase: CamelCaser.toLowerCamelCase(descriptor.name)
     )
     let documentation = descriptor.protoSourceComments()
     self.init(

--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
@@ -124,7 +124,8 @@ extension CodeGenerationRequest.ServiceDescriptor {
     }
     let name = CodeGenerationRequest.Name(
       base: descriptor.name,
-      generatedUpperCase: descriptor.name,  // The service name from the '.proto' file is expected to be in upper camel case
+      // The service name from the '.proto' file is expected to be in upper camel case
+      generatedUpperCase: descriptor.name,
       generatedLowerCase: CamelCaser.toLowerCamelCase(descriptor.name)
     )
 
@@ -144,7 +145,8 @@ extension CodeGenerationRequest.ServiceDescriptor.MethodDescriptor {
   fileprivate init(descriptor: MethodDescriptor, protobufNamer: SwiftProtobufNamer) {
     let name = CodeGenerationRequest.Name(
       base: descriptor.name,
-      generatedUpperCase: descriptor.name,  // The method name from the '.proto' file is expected to be in upper camel case
+      // The method name from the '.proto' file is expected to be in upper camel case
+      generatedUpperCase: descriptor.name,
       generatedLowerCase: CamelCaser.toLowerCamelCase(descriptor.name)
     )
     let documentation = descriptor.protoSourceComments()

--- a/Tests/GRPCProtobufCodeGenTests/CamelCaserTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/CamelCaserTests.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCProtobufCodeGen
+import Testing
+
+@Suite("CamelCaser")
+struct CamelCaserTests {
+  @Test(
+    "Convert to lower camel case",
+    arguments: [
+      ("ImportCsv", "importCsv"),
+      ("ImportCSV", "importCSV"),
+      ("CSVImport", "csvImport"),
+      ("importCSV", "importCSV"),
+      ("FOOBARImport", "foobarImport"),
+      ("FOO_BARImport", "foo_barImport"),
+      ("My_CSVImport", "my_CSVImport"),
+      ("_CSVImport", "_csvImport"),
+      ("V2Request", "v2Request"),
+      ("V2_Request", "v2_Request"),
+      ("CSV", "csv"),
+      ("I", "i"),
+      ("i", "i"),
+      ("I_", "i_"),
+      ("_", "_"),
+      ("", ""),
+    ]
+  )
+  func toLowerCamelCase(_ input: String, expectedOutput: String) async throws {
+    #expect(CamelCaser.toLowerCamelCase(input) == expectedOutput)
+  }
+}


### PR DESCRIPTION
Motivation:

Given a method name, say `ImportCSV`, from a `.proto` file, the generated method name in upper and lower camel case is `ImportCsv` and `importCsv` respectively. The generated method name (which is already expected to be in upper camel case) in upper and lower camel case should be `ImportCSV` and `importCSV` respectively.

Modifications:

- Replace the method used for generating service and method names in lower camel case with a newly implemented method.
- Do not convert the base names of services and methods to upper camel case as they are expected to already be in upper camel case.

Result:

The casing of service and method names will be preserved when generating stubs.