### PR TITLE
Depend on `grpc-swift/main`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    exact: "2.0.0-alpha.1"
+    branch: "main"
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",


### PR DESCRIPTION
## Motivation
We should depend on `grpc-swift/main` for now to make sure that everything works cross-package.

## Modifications
This PR changes `grpc-swift-protobuf` to depend on `main` for `grpc-swift`. It also fixes some tests as a result of adding the cancellation handler to the API.

## Result
`grpc-swift-extras` builds with the latest `grpc-swift` changes.