### PR TITLE
Add more build settings to test targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,8 @@ let targets: [Target] = [
       .product(name: "GRPCCodeGen", package: "grpc-swift"),
       .product(name: "SwiftProtobuf", package: "swift-protobuf"),
       .product(name: "SwiftProtobufPluginLibrary", package: "swift-protobuf"),
-    ]
+    ],
+    swiftSettings: defaultSwiftSettings
   ),
 
   // Runtime serialization components
@@ -72,7 +73,8 @@ let targets: [Target] = [
       .target(name: "GRPCProtobuf"),
       .product(name: "GRPCCore", package: "grpc-swift"),
       .product(name: "SwiftProtobuf", package: "swift-protobuf"),
-    ]
+    ],
+    swiftSettings: defaultSwiftSettings
   ),
 
   // Code generator library for protoc-gen-grpc-swift
@@ -91,7 +93,8 @@ let targets: [Target] = [
       .product(name: "GRPCCodeGen", package: "grpc-swift"),
       .product(name: "SwiftProtobuf", package: "swift-protobuf"),
       .product(name: "SwiftProtobufPluginLibrary", package: "swift-protobuf"),
-    ]
+    ],
+    swiftSettings: defaultSwiftSettings
   )
 ]
 

--- a/Sources/protoc-gen-grpc-swift/Options.swift
+++ b/Sources/protoc-gen-grpc-swift/Options.swift
@@ -22,7 +22,7 @@ enum GenerationError: Error {
   /// Raised when a parameter was giving an invalid value
   case invalidParameterValue(name: String, value: String)
   /// Raised to wrap another error but provide a context message.
-  case wrappedError(message: String, error: Error)
+  case wrappedError(message: String, error: any Error)
 
   var localizedDescription: String {
     switch self {


### PR DESCRIPTION
Motivation:

The test targets don't set the same Swift as the library targets. There's no reason for them not to.

Modifications:

- Apply default settings to test targets.
- Add missing 'any'

Result:

Test targets use Swift 6 language mode, explicit existential any, and internal imports by default