### PR TITLE
Always include the 'SwiftProtobuf' import in generated code

### DIFF
--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
@@ -96,7 +96,8 @@ extension ProtobufCodeGenParser {
     file: FileDescriptor
   ) -> [Dependency] {
     var codeDependencies: [Dependency] = [
-      .init(module: "GRPCProtobuf", accessLevel: .internal)
+      Dependency(module: "GRPCProtobuf", accessLevel: .internal),
+      Dependency(module: "SwiftProtobuf", accessLevel: self.accessLevel),
     ]
     // Adding as dependencies the modules containing generated code or types for
     // '.proto' files imported in the '.proto' file we are parsing.

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
@@ -61,7 +61,8 @@ struct ProtobufCodeGenParserTests {
     @Test("Dependencies")
     func dependencies() {
       let expected: [GRPCCodeGen.Dependency] = [
-        .init(module: "GRPCProtobuf", accessLevel: .internal)  // Always an internal import
+        .init(module: "GRPCProtobuf", accessLevel: .internal),  // Always an internal import
+        .init(module: "SwiftProtobuf", accessLevel: .internal),
       ]
       #expect(self.codeGen.dependencies == expected)
     }
@@ -173,7 +174,8 @@ struct ProtobufCodeGenParserTests {
     @Test("Dependencies")
     func dependencies() {
       let expected: [GRPCCodeGen.Dependency] = [
-        .init(module: "GRPCProtobuf", accessLevel: .internal)  // Always an internal import
+        .init(module: "GRPCProtobuf", accessLevel: .internal),  // Always an internal import
+        .init(module: "SwiftProtobuf", accessLevel: .internal),
       ]
       #expect(self.codeGen.dependencies == expected)
     }

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -67,6 +67,7 @@ struct ProtobufCodeGeneratorTests: UsesDescriptorSet {
 
       import GRPCCore
       import GRPCProtobuf
+      import SwiftProtobuf
 
       // MARK: - test.TestService
 


### PR DESCRIPTION
Motivation:

The 'SwiftProtobuf' import was missing from generated code.

Modifications:

- Always generate an import for 'SwiftProtobuf'

Result:

Import are more correct