### PR TITLE
Ignore case for boolean option values in protoc-gen-grpc-swift

### DIFF
--- a/Sources/protoc-gen-grpc-swift/Options.swift
+++ b/Sources/protoc-gen-grpc-swift/Options.swift
@@ -88,14 +88,14 @@ struct GeneratorOptions {
         }
 
       case "Server":
-        if let value = Bool(pair.value) {
+        if let value = Bool(pair.value.lowercased()) {
           self.generateServer = value
         } else {
           throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
         }
 
       case "Client":
-        if let value = Bool(pair.value) {
+        if let value = Bool(pair.value.lowercased()) {
           self.generateClient = value
         } else {
           throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
@@ -142,14 +142,14 @@ struct GeneratorOptions {
         }
 
       case "ReflectionData":
-        if let value = Bool(pair.value) {
+        if let value = Bool(pair.value.lowercased()) {
           self.generateReflectionData = value
         } else {
           throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
         }
 
       case "UseAccessLevelOnImports":
-        if let value = Bool(pair.value) {
+        if let value = Bool(pair.value.lowercased()) {
           self.useAccessLevelOnImports = value
         } else {
           throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)


### PR DESCRIPTION
Motivation:

The protoc-gen-grpc-swift plugin has a few boolean options which currently require a lowercased value. This is overly strict, the casing of "true"/"false" shouldn't matter.

Modifications:

- Ignore case for boolean optioned values

Result:

Easier to use protoc-gen-grpc-swift