### PR TITLE
Use FoundationEssentials where possible

### DIFF
--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-internal import Foundation
 internal import SwiftProtobuf
 package import SwiftProtobufPluginLibrary
 
@@ -24,6 +23,12 @@ package import struct GRPCCodeGen.MethodDescriptor
 package import struct GRPCCodeGen.Name
 package import struct GRPCCodeGen.ServiceDescriptor
 package import struct GRPCCodeGen.SourceGenerator
+
+#if canImport(FoundationEssentials)
+internal import struct FoundationEssentials.IndexPath
+#else
+internal import struct Foundation.IndexPath
+#endif
 
 /// Parses a ``FileDescriptor`` object into a ``CodeGenerationRequest`` object.
 package struct ProtobufCodeGenParser {

--- a/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
+++ b/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-import Foundation
 import GRPCCodeGen
 import GRPCProtobufCodeGen
 import SwiftProtobuf
 import SwiftProtobufPluginLibrary
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @main
 final class GenerateGRPC: CodeGenerator {
@@ -146,8 +151,7 @@ extension GenerateGRPC {
     case .fullPath:
       return pathParts.dir + pathParts.base + ext
     case .pathToUnderscores:
-      let dirWithUnderscores =
-        pathParts.dir.replacingOccurrences(of: "/", with: "_")
+      let dirWithUnderscores = pathParts.dir.replacing("/", with: "_")
       return dirWithUnderscores + pathParts.base + ext
     case .dropPath:
       return pathParts.base + ext


### PR DESCRIPTION
Motivation:

FoundationEssentials only includes ... the essentials. We should use it where available.

Modifications:

- Remove unused Foundation imports
- Replace a Foundation import with a FoundationEssentials import

Result:

Smaller dependency set