### PR TITLE
Generate code file for protos with no definitions

### DIFF
--- a/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
+++ b/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
@@ -63,10 +63,6 @@ final class GenerateGRPC: CodeGenerator {
         )
       }
 
-      if descriptor.services.isEmpty {
-        continue
-      }
-
       try self.generateV2Stubs(descriptor, options: options, outputs: outputs)
     }
   }


### PR DESCRIPTION
This change is broken out of https://github.com/grpc/grpc-swift-protobuf/pull/26

### Motivation

To prepare for use in a SwiftPM build plugin which requires deterministic output files and to match the behavior of `proto-gen-swift` we should generate a source file even if no definitions are found.

### Modifications:

We no longer return early in the case of no definitions being found.

### Result:

We will generate a Swift source file even if no definitions are found.