### PR TITLE
Remove percent-encoded chars in build plugin paths

### DIFF
--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -109,8 +109,10 @@ func constructProtocGenGRPCSwiftArguments(
 
 extension URL {
   /// Returns `URL.absoluteString` with the `file://` scheme prefix removed
+  ///
+  /// Note: This method also removes percent-encoded UTF-8 characters
   var absoluteStringNoScheme: String {
-    var absoluteString = self.absoluteString
+    var absoluteString = self.absoluteString.removingPercentEncoding ?? self.absoluteString
     absoluteString.trimPrefix("file://")
     return absoluteString
   }


### PR DESCRIPTION
### Motivation:

Xcode provides paths to executables as strings referencing environment variables and then passes those strings to the build plugin as URLs. This meant that when we converted these URLs to strings they percent-encoded some characters and were no longer valid paths e.g.

```
/${BUILD_DIR}/${CONFIGURATION}/protoc-gen-swift
```
became
```
/$%7BBUILD_DIR%7D/$%7BCONFIGURATION%7D/protoc-gen-swift
```

### Modifications:

Have our utility function for accessing absolute paths as strings strip percent-encoding.

### Result:

The build plugin works in Xcode