### PR TITLE
Fix warnings about unused value in plugin error

### DIFF
--- a/Plugins/PluginsShared/PluginError.swift
+++ b/Plugins/PluginsShared/PluginError.swift
@@ -23,8 +23,8 @@ enum PluginError: Error {
 extension PluginError: CustomStringConvertible {
   var description: String {
     switch self {
-    case .incompatibleTarget(let string):
-      "Build plugin applied to incompatible target."
+    case .incompatibleTarget(let target):
+      "Build plugin applied to incompatible target (\(target))."
     case .noConfigFilesFound:
       "No config files found. The build plugin relies on the existence of one or more '\(configFileName)' files in the target source."
     }


### PR DESCRIPTION
Motivation:

The plugin error case for an incompatible target has an associated value which is currently ignored.

Modifications:

- Use the value

Result:

Fewer warnings