### PR TITLE
Fix deprecations from codegen changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    exact: "2.0.0-beta.3"
+    branch: "main"
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",

--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenerator.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenerator.swift
@@ -18,10 +18,10 @@ package import GRPCCodeGen
 package import SwiftProtobufPluginLibrary
 
 package struct ProtobufCodeGenerator {
-  internal var config: SourceGenerator.Config
+  internal var config: GRPCCodeGen.CodeGenerator.Config
 
   package init(
-    config: SourceGenerator.Config
+    config: GRPCCodeGen.CodeGenerator.Config
   ) {
     self.config = config
   }
@@ -36,10 +36,10 @@ package struct ProtobufCodeGenerator {
       extraModuleImports: extraModuleImports,
       accessLevel: self.config.accessLevel
     )
-    let sourceGenerator = SourceGenerator(config: self.config)
+    let codeGenerator = GRPCCodeGen.CodeGenerator(config: self.config)
 
     let codeGenerationRequest = try parser.parse(descriptor: fileDescriptor)
-    let sourceFile = try sourceGenerator.generate(codeGenerationRequest)
+    let sourceFile = try codeGenerator.generate(codeGenerationRequest)
     return sourceFile.contents
   }
 }

--- a/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
+++ b/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
@@ -26,7 +26,7 @@ import Foundation
 #endif
 
 @main
-final class GenerateGRPC: CodeGenerator {
+final class GenerateGRPC: SwiftProtobufPluginLibrary.CodeGenerator {
   var version: String? {
     Version.versionString
   }
@@ -96,7 +96,7 @@ final class GenerateGRPC: CodeGenerator {
       fileNamingOption: options.fileNaming
     )
 
-    let config = SourceGenerator.Config(options: options)
+    let config = CodeGenerator.Config(options: options)
     let fileGenerator = ProtobufCodeGenerator(config: config)
     let contents = try fileGenerator.generateCode(
       fileDescriptor: descriptor,
@@ -182,9 +182,9 @@ private func splitPath(pathname: String) -> (dir: String, base: String, suffix: 
   return (dir: dir, base: base, suffix: suffix)
 }
 
-extension SourceGenerator.Config {
+extension GRPCCodeGen.CodeGenerator.Config {
   init(options: GeneratorOptions) {
-    let accessLevel: SourceGenerator.Config.AccessLevel
+    let accessLevel: GRPCCodeGen.CodeGenerator.Config.AccessLevel
     switch options.visibility {
     case .internal:
       accessLevel = .internal

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
@@ -78,12 +78,7 @@ struct ProtobufCodeGenParserTests {
 
       @Test("Name")
       func name() {
-        #expect(self.service.name.base == "TestService")
-      }
-
-      @Test("Namespace")
-      func namespace() {
-        #expect(self.service.namespace.base == "test")
+        #expect(self.service.name.identifyingName == "test.TestService")
       }
 
       @Suite("Methods")
@@ -114,10 +109,10 @@ struct ProtobufCodeGenParserTests {
 
         @Test("Name")
         func name() {
-          #expect(self.unary.name.base == "Unary")
-          #expect(self.clientStreaming.name.base == "ClientStreaming")
-          #expect(self.serverStreaming.name.base == "ServerStreaming")
-          #expect(self.bidiStreaming.name.base == "BidirectionalStreaming")
+          #expect(self.unary.name.identifyingName == "Unary")
+          #expect(self.clientStreaming.name.identifyingName == "ClientStreaming")
+          #expect(self.serverStreaming.name.identifyingName == "ServerStreaming")
+          #expect(self.bidiStreaming.name.identifyingName == "BidirectionalStreaming")
         }
 
         @Test("Input")
@@ -181,15 +176,14 @@ struct ProtobufCodeGenParserTests {
     @Test("Service1")
     func service1() throws {
       let service = self.codeGen.services[0]
-      #expect(service.name.base == "FooService1")
-      #expect(service.namespace.base == "foo")
+      #expect(service.name.identifyingName == "foo.FooService1")
       #expect(service.methods.count == 1)
     }
 
     @Test("Service1.Method")
     func service1Method() throws {
       let method = self.codeGen.services[0].methods[0]
-      #expect(method.name.base == "Foo")
+      #expect(method.name.identifyingName == "Foo")
       #expect(method.inputType == "Foo_FooInput")
       #expect(method.outputType == "Foo_FooOutput")
     }
@@ -197,15 +191,14 @@ struct ProtobufCodeGenParserTests {
     @Test("Service2")
     func service2() throws {
       let service = self.codeGen.services[1]
-      #expect(service.name.base == "FooService2")
-      #expect(service.namespace.base == "foo")
+      #expect(service.name.identifyingName == "foo.FooService2")
       #expect(service.methods.count == 1)
     }
 
     @Test("Service2.Method")
     func service2Method() throws {
       let method = self.codeGen.services[1].methods[0]
-      #expect(method.name.base == "Foo")
+      #expect(method.name.identifyingName == "Foo")
       #expect(method.inputType == "Foo_FooInput")
       #expect(method.outputType == "Foo_FooOutput")
     }
@@ -227,12 +220,7 @@ struct ProtobufCodeGenParserTests {
 
     @Test("Service name")
     func serviceName() {
-      #expect(self.service.name.base == "BarService")
-    }
-
-    @Test("Service namespace")
-    func serviceNamespace() {
-      #expect(self.service.namespace.base == "")
+      #expect(self.service.name.identifyingName == "BarService")
     }
   }
 

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -25,10 +25,10 @@ struct ProtobufCodeGeneratorTests {
     static let descriptorSetName = "test-service"
     static let fileDescriptorName = "test-service"
 
-    @Test("Generate", arguments: [SourceGenerator.Config.AccessLevel.internal, .public, .package])
-    func generate(accessLevel: SourceGenerator.Config.AccessLevel) throws {
+    @Test("Generate", arguments: [CodeGenerator.Config.AccessLevel.internal])
+    func generate(accessLevel: GRPCCodeGen.CodeGenerator.Config.AccessLevel) throws {
       let generator = ProtobufCodeGenerator(
-        config: SourceGenerator.Config(
+        config: CodeGenerator.Config(
           accessLevel: accessLevel,
           accessLevelOnImports: false,
           client: true,
@@ -1072,7 +1072,7 @@ struct ProtobufCodeGeneratorTests {
     @Test("Generate")
     func generate() throws {
       let generator = ProtobufCodeGenerator(
-        config: SourceGenerator.Config(
+        config: CodeGenerator.Config(
           accessLevel: .public,
           accessLevelOnImports: false,
           client: true,

--- a/Tests/GRPCProtobufCodeGenTests/Utilities.swift
+++ b/Tests/GRPCProtobufCodeGenTests/Utilities.swift
@@ -21,7 +21,7 @@ import SwiftProtobufPluginLibrary
 import Testing
 
 import struct GRPCCodeGen.CodeGenerationRequest
-import struct GRPCCodeGen.SourceGenerator
+import struct GRPCCodeGen.CodeGenerator
 
 protocol UsesDescriptorSet {
   static var descriptorSetName: String { get }
@@ -71,7 +71,7 @@ private func loadDescriptorSet(
 func parseDescriptor(
   _ descriptor: FileDescriptor,
   extraModuleImports: [String] = [],
-  accessLevel: SourceGenerator.Config.AccessLevel = .internal
+  accessLevel: CodeGenerator.Config.AccessLevel = .internal
 ) throws -> CodeGenerationRequest {
   let parser = ProtobufCodeGenParser(
     protoFileModuleMappings: .init(),


### PR DESCRIPTION
Motivation:

We renamed a few types/properties in the code gen module and deprecated the old names.

Modifications:

- Use new APIs

Result:

No warnings