### PR TITLE
Align on config name for use import access level

### DIFF
--- a/Plugins/GRPCProtobufGenerator/BuildPluginConfig.swift
+++ b/Plugins/GRPCProtobufGenerator/BuildPluginConfig.swift
@@ -57,16 +57,16 @@ struct BuildPluginConfig: Codable {
     /// Whether imports should have explicit access levels.
     ///
     /// Defaults to `false`.
-    var useAccessLevelOnImports: Bool
+    var accessLevelOnImports: Bool
 
     static let defaults = Self(
       accessLevel: .internal,
-      useAccessLevelOnImports: false
+      accessLevelOnImports: false
     )
 
-    private init(accessLevel: GenerationConfig.AccessLevel, useAccessLevelOnImports: Bool) {
+    private init(accessLevel: GenerationConfig.AccessLevel, accessLevelOnImports: Bool) {
       self.accessLevel = accessLevel
-      self.useAccessLevelOnImports = useAccessLevelOnImports
+      self.accessLevelOnImports = accessLevelOnImports
     }
   }
 
@@ -159,7 +159,7 @@ extension BuildPluginConfig.GeneratedSource: Codable {
   // Codable conformance with defaults
   enum CodingKeys: String, CodingKey {
     case accessLevel
-    case useAccessLevelOnImports
+    case accessLevelOnImports
   }
 
   init(from decoder: any Decoder) throws {
@@ -168,9 +168,9 @@ extension BuildPluginConfig.GeneratedSource: Codable {
     self.accessLevel =
       try container.decodeIfPresent(GenerationConfig.AccessLevel.self, forKey: .accessLevel)
       ?? Self.defaults.accessLevel
-    self.useAccessLevelOnImports =
-      try container.decodeIfPresent(Bool.self, forKey: .useAccessLevelOnImports)
-      ?? Self.defaults.useAccessLevelOnImports
+    self.accessLevelOnImports =
+      try container.decodeIfPresent(Bool.self, forKey: .accessLevelOnImports)
+      ?? Self.defaults.accessLevelOnImports
   }
 }
 
@@ -199,7 +199,7 @@ extension GenerationConfig {
     // hard-code full-path to avoid collisions since this goes into a temporary directory anyway
     self.fileNaming = .fullPath
     self.visibility = buildPluginConfig.generatedSource.accessLevel
-    self.useAccessLevelOnImports = buildPluginConfig.generatedSource.useAccessLevelOnImports
+    self.accessLevelOnImports = buildPluginConfig.generatedSource.accessLevelOnImports
     // Generate absolute paths for the imports relative to the config file in which they are specified
     self.importPaths = buildPluginConfig.protoc.importPaths.map { relativePath in
       configFilePath.deletingLastPathComponent().absoluteStringNoScheme + "/" + relativePath

--- a/Plugins/PluginsShared/GenerationConfig.swift
+++ b/Plugins/PluginsShared/GenerationConfig.swift
@@ -52,7 +52,7 @@ struct GenerationConfig {
   /// The naming of output files with respect to the path of the source file.
   var fileNaming: FileNaming
   /// Whether imports should have explicit access levels.
-  var useAccessLevelOnImports: Bool
+  var accessLevelOnImports: Bool
 
   /// Specify the directory in which to search for imports.
   ///

--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -65,7 +65,7 @@ func constructProtocGenSwiftArguments(
 
   protocArgs.append("--swift_opt=Visibility=\(config.visibility.rawValue)")
   protocArgs.append("--swift_opt=FileNaming=\(config.fileNaming.rawValue)")
-  protocArgs.append("--swift_opt=UseAccessLevelOnImports=\(config.useAccessLevelOnImports)")
+  protocArgs.append("--swift_opt=UseAccessLevelOnImports=\(config.accessLevelOnImports)")
   protocArgs.append(contentsOf: inputFiles.map { $0.absoluteStringNoScheme })
 
   return protocArgs
@@ -101,7 +101,7 @@ func constructProtocGenGRPCSwiftArguments(
   protocArgs.append("--grpc-swift_opt=Server=\(config.server)")
   protocArgs.append("--grpc-swift_opt=Client=\(config.client)")
   protocArgs.append("--grpc-swift_opt=FileNaming=\(config.fileNaming.rawValue)")
-  protocArgs.append("--grpc-swift_opt=UseAccessLevelOnImports=\(config.useAccessLevelOnImports)")
+  protocArgs.append("--grpc-swift_opt=UseAccessLevelOnImports=\(config.accessLevelOnImports)")
   protocArgs.append(contentsOf: inputFiles.map { $0.absoluteStringNoScheme })
 
   return protocArgs


### PR DESCRIPTION
Motivation:

When the plugin was done we went through a few iterations of the shape of config and settled on `accessLevelOnImports` vs. `useAccessLevelOnImports` but that change wasn't made.

Modifications:

- Update config name.

Result:

API is what we planned it to be.