### PR TITLE
Remove explicit 'GITHUB_ACTIONS=true'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           MATRIX_LINUX_5_9_ENABLED: false
           MATRIX_LINUX_5_10_ENABLED: false
-          MATRIX_LINUX_COMMAND: "GITHUB_ACTIONS=true ./dev/plugin-tests.sh"
+          MATRIX_LINUX_COMMAND: "./dev/plugin-tests.sh"
           MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q curl protobuf-compiler"
 
   plugin-tests-matrix:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           MATRIX_LINUX_5_9_ENABLED: false
           MATRIX_LINUX_5_10_ENABLED: false
-          MATRIX_LINUX_COMMAND: "GITHUB_ACTIONS=true ./dev/plugin-tests.sh"
+          MATRIX_LINUX_COMMAND: "./dev/plugin-tests.sh"
           MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q curl protobuf-compiler"
 
   plugin-tests-matrix:


### PR DESCRIPTION
Motivation:

It is no longer required.

Modifications:

Remove explicit 'GITHUB_ACTIONS=true' from workflows, it's now set automatically.

Result:

Clearer config.