### PR TITLE
Don't generate reflection data.

### DIFF
--- a/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
+++ b/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
@@ -55,35 +55,8 @@ final class GenerateGRPC: SwiftProtobufPluginLibrary.CodeGenerator {
     let options = try GeneratorOptions(parameter: parameter)
 
     for descriptor in fileDescriptors {
-      if options.generateReflectionData {
-        try self.generateReflectionData(
-          descriptor,
-          options: options,
-          outputs: outputs
-        )
-      }
-
       try self.generateV2Stubs(descriptor, options: options, outputs: outputs)
     }
-  }
-
-  private func generateReflectionData(
-    _ descriptor: FileDescriptor,
-    options: GeneratorOptions,
-    outputs: any GeneratorOutputs
-  ) throws {
-    let fileName = self.uniqueOutputFileName(
-      fileDescriptor: descriptor,
-      fileNamingOption: options.fileNaming,
-      extension: "reflection"
-    )
-
-    var options = ExtractProtoOptions()
-    options.includeSourceCodeInfo = true
-    let proto = descriptor.extractProto(options: options)
-    let serializedProto = try proto.serializedData()
-    let reflectionData = serializedProto.base64EncodedString()
-    try outputs.add(fileName: fileName, contents: reflectionData)
   }
 
   private func generateV2Stubs(


### PR DESCRIPTION
Motivation:

v1 generated reflection data via the protoc plugin; this wasn't remvoed from v2 but the v2 reflection servcice doesn't use data in the same format. Instead, v2 expects users to invoke protoc directly to generate a descriptor set. This makes the option redundant: it can be called but the output can't be used.

Modifications:

- Remove the reflection data generating code and have the option throw an error.

Result:

Less code