### PR TITLE
Add command plugin to package products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,10 @@ let products: [Product] = [
     name: "GRPCProtobufGenerator",
     targets: ["GRPCProtobufGenerator"]
   ),
+  .plugin(
+    name: "generate-grpc-code-from-protos",
+    targets: ["generate-grpc-code-from-protos"]
+  ),
 ]
 
 let dependencies: [Package.Dependency] = [
@@ -118,7 +122,7 @@ let targets: [Target] = [
 
   // Code generator SwiftPM command
   .plugin(
-    name: "GRPCProtobufGeneratorCommand",
+    name: "generate-grpc-code-from-protos",
     capability: .command(
       intent: .custom(
         verb: "generate-grpc-code-from-protos",
@@ -134,7 +138,8 @@ let targets: [Target] = [
     dependencies: [
       .target(name: "protoc-gen-grpc-swift"),
       .product(name: "protoc-gen-swift", package: "swift-protobuf"),
-    ]
+    ],
+    path: "Plugins/GRPCProtobufGeneratorCommand"
   ),
 ]
 

--- a/Plugins/GRPCProtobufGeneratorCommand/Plugin.swift
+++ b/Plugins/GRPCProtobufGeneratorCommand/Plugin.swift
@@ -145,7 +145,7 @@ struct GRPCProtobufGeneratorCommandPlugin {
         outputDirectory: outputDirectory
       )
 
-      let completionStatus = try executeProtocInvocation(
+      try executeProtocInvocation(
         executableURL: protocPath,
         arguments: arguments,
         verbose: commandConfig.verbose,
@@ -229,8 +229,6 @@ func executeProtocInvocation(
     arguments: arguments,
     stdErr: stdErr
   )
-
-  return
 }
 
 func printProtocOutput(_ stdOut: Pipe, verbose: Bool) throws {


### PR DESCRIPTION
Motivation:

The command plugin needs to be a product in order for it to be used.

Modifications:

- Add it to the products
- Give it the same name as the command, otherwise diagnostics (like SwiftPM asking for permission to write to the package dir) will use a different name which isn't obvious.
- Fix a few build warnings.

Result:

- Command plugin can be used