### PR TITLE
Fix a few warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   construct-plugin-tests-matrix:
     name: Construct plugin tests matrix

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,10 +22,10 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   construct-plugin-tests-matrix:
     name: Construct plugin tests matrix

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
@@ -30,7 +30,7 @@ struct ProtobufCodeGenParserTests {
     let codeGen: CodeGenerationRequest
 
     init() throws {
-      let descriptor = try #require(try Self.fileDescriptor)
+      let descriptor = try Self.fileDescriptor
       self.codeGen = try parseDescriptor(descriptor)
     }
 
@@ -73,7 +73,7 @@ struct ProtobufCodeGenParserTests {
       let service: GRPCCodeGen.ServiceDescriptor
 
       init() throws {
-        let request = try parseDescriptor(try #require(try TestService.fileDescriptor))
+        let request = try parseDescriptor(try TestService.fileDescriptor)
         try #require(request.services.count == 1)
         self.service = try #require(request.services.first)
       }
@@ -91,7 +91,7 @@ struct ProtobufCodeGenParserTests {
         let bidiStreaming: GRPCCodeGen.MethodDescriptor
 
         init() throws {
-          let request = try parseDescriptor(try #require(try TestService.fileDescriptor))
+          let request = try parseDescriptor(try TestService.fileDescriptor)
           #expect(request.services.count == 1)
           let service = try #require(request.services.first)
 
@@ -158,7 +158,7 @@ struct ProtobufCodeGenParserTests {
     let codeGen: CodeGenerationRequest
 
     init() throws {
-      let descriptor = try #require(try Self.fileDescriptor)
+      let descriptor = try Self.fileDescriptor
       self.codeGen = try parseDescriptor(descriptor)
     }
 
@@ -215,7 +215,7 @@ struct ProtobufCodeGenParserTests {
     let service: GRPCCodeGen.ServiceDescriptor
 
     init() throws {
-      let descriptor = try #require(try Self.fileDescriptor)
+      let descriptor = try Self.fileDescriptor
       self.codeGen = try parseDescriptor(descriptor)
       self.service = try #require(self.codeGen.services.first)
     }
@@ -234,7 +234,7 @@ struct ProtobufCodeGenParserTests {
     let codeGen: CodeGenerationRequest
 
     init() throws {
-      let descriptor = try #require(try Self.fileDescriptor)
+      let descriptor = try Self.fileDescriptor
       self.codeGen = try parseDescriptor(descriptor)
     }
 

--- a/Tests/GRPCProtobufCodeGenTests/Utilities.swift
+++ b/Tests/GRPCProtobufCodeGenTests/Utilities.swift
@@ -63,7 +63,7 @@ private func loadDescriptorSet(
   )
 
   let url = try #require(maybeURL)
-  let data = try #require(try Data(contentsOf: url))
+  let data = try Data(contentsOf: url)
   let descriptorSet = try Google_Protobuf_FileDescriptorSet(serializedBytes: data)
   return DescriptorSet(proto: descriptorSet)
 }


### PR DESCRIPTION
Motivation:

Swift 6.1 emits a few new warnings from Swift Testing

Modifications:

- Remove redundant `#require` macros
- Enable warnings as errors in CI
- Remove `-require-explicit-sendable` as it wasn't enabled correctly (it requires `-Xfrontend` and is currently incompatible with `-warnings-as-errors`)

Result:

Fewer warnings