### PR TITLE
Regenerate code for tests

### DIFF
--- a/Tests/GRPCProtobufTests/Errors/Generated/error-service.grpc.swift
+++ b/Tests/GRPCProtobufTests/Errors/Generated/error-service.grpc.swift
@@ -30,6 +30,7 @@ internal import SwiftProtobuf
 // MARK: - ErrorService
 
 /// Namespace containing generated types for the "ErrorService" service.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal enum ErrorService {
     /// Service descriptor for the "ErrorService" service.
     internal static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "ErrorService")
@@ -54,6 +55,7 @@ internal enum ErrorService {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCCore.ServiceDescriptor {
     /// Service descriptor for the "ErrorService" service.
     internal static let ErrorService = GRPCCore.ServiceDescriptor(fullyQualifiedService: "ErrorService")
@@ -61,6 +63,7 @@ extension GRPCCore.ServiceDescriptor {
 
 // MARK: ErrorService (server)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ErrorService {
     /// Streaming variant of the service protocol for the "ErrorService" service.
     ///
@@ -134,6 +137,7 @@ extension ErrorService {
 }
 
 // Default implementation of 'registerMethods(with:)'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ErrorService.StreamingServiceProtocol {
     internal func registerMethods<Transport>(with router: inout GRPCCore.RPCRouter<Transport>) where Transport: GRPCCore.ServerTransport {
         router.registerHandler(
@@ -151,6 +155,7 @@ extension ErrorService.StreamingServiceProtocol {
 }
 
 // Default implementation of streaming methods from 'StreamingServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ErrorService.ServiceProtocol {
     internal func throwError(
         request: GRPCCore.StreamingServerRequest<ThrowInput>,
@@ -165,6 +170,7 @@ extension ErrorService.ServiceProtocol {
 }
 
 // Default implementation of methods from 'ServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ErrorService.SimpleServiceProtocol {
     internal func throwError(
         request: GRPCCore.ServerRequest<ThrowInput>,
@@ -182,6 +188,7 @@ extension ErrorService.SimpleServiceProtocol {
 
 // MARK: ErrorService (client)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ErrorService {
     /// Generated client protocol for the "ErrorService" service.
     ///
@@ -257,6 +264,7 @@ extension ErrorService {
 }
 
 // Helpers providing default arguments to 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ErrorService.ClientProtocol {
     /// Call the "ThrowError" method.
     ///
@@ -285,6 +293,7 @@ extension ErrorService.ClientProtocol {
 }
 
 // Helpers providing sugared APIs for 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ErrorService.ClientProtocol {
     /// Call the "ThrowError" method.
     ///


### PR DESCRIPTION
Motivation:

The generated code used in tests is out of date. This happened because of an update to grpc-swift and the GitHub actions job to check generated code wasn't a required status check (but now is).

Modifications:

- Regenerate generated code

Result:

Generated code check passes