### PR TITLE
Set version info using info from the package context

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,8 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
       license_header_check_project_name: "gRPC"
+      # See Package.swift for an explanation of this.
+      linux_pre_build_command: "export GRPC_SWIFT_PROTOBUF_NO_VERSION=1"
 
   grpc-soundness:
     name: Soundness

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,8 +11,9 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
       license_header_check_project_name: "gRPC"
-      # See Package.swift for an explanation of this.
-      linux_pre_build_command: "export GRPC_SWIFT_PROTOBUF_NO_VERSION=1"
+      # This is done by a similar job defined in soundness.yml. It needs to be
+      # separate in order to export an environment variable.
+      api_breakage_check_enabled: false
 
   grpc-soundness:
     name: Soundness

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -35,3 +35,28 @@ jobs:
       - name: Check generated code
         run: |
           ./dev/check-generated-code.sh
+
+  api-breakage-check:
+    name: API breakage check
+    runs-on: ubuntu-latest
+    container:
+      image: swift:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0  # Fetching tags requires fetch-depth: 0 (https://github.com/actions/checkout/issues/1471)
+      - name: Mark the workspace as safe
+        # https://github.com/actions/checkout/issues/766
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Run API breakage check
+        shell: bash
+        # See package.swift for why we set GRPC_SWIFT_PROTOBUF_NO_VERSION=1
+        run: |
+          export GRPC_SWIFT_PROTOBUF_NO_VERSION=1
+
+          git fetch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} ${GITHUB_BASE_REF}:pull-base-ref
+          BASELINE_REF='pull-base-ref'
+          echo "Using baseline: $BASELINE_REF"
+          swift package diagnose-api-breaking-changes "$BASELINE_REF"

--- a/Package.swift
+++ b/Package.swift
@@ -54,12 +54,26 @@ let defaultSwiftSettings: [SwiftSetting] = [
   .enableUpcomingFeature("MemberImportVisibility"),
 ]
 
+extension Context {
+  fileprivate static var versionString: String {
+    guard let git = Self.gitInformation else { return "" }
+
+    if let tag = git.currentTag {
+      return tag
+    } else {
+      let suffix = git.hasUncommittedChanges ? " (modified)" : ""
+      return git.currentCommit + suffix
+    }
+  }
+}
+
 let targets: [Target] = [
   // protoc plugin for grpc-swift
   .executableTarget(
     name: "protoc-gen-grpc-swift",
     dependencies: [
       .target(name: "GRPCProtobufCodeGen"),
+      .target(name: "CGRPCProtobuf"),
       .product(name: "GRPCCodeGen", package: "grpc-swift"),
       .product(name: "SwiftProtobuf", package: "swift-protobuf"),
       .product(name: "SwiftProtobufPluginLibrary", package: "swift-protobuf"),
@@ -108,6 +122,13 @@ let targets: [Target] = [
       .copy("Generated")
     ],
     swiftSettings: defaultSwiftSettings
+  ),
+
+  .target(
+    name: "CGRPCProtobuf",
+    cSettings: [
+      .define("CGRPC_GRPC_SWIFT_PROTOBUF_VERSION", to: "\"\(Context.versionString)\"")
+    ]
   ),
 
   // Code generator build plugin

--- a/Package.swift
+++ b/Package.swift
@@ -110,7 +110,6 @@ var targets: [Target] = [
     swiftSettings: defaultSwiftSettings
   ),
 
-
   // Code generator build plugin
   .plugin(
     name: "GRPCProtobufGenerator",

--- a/Sources/CGRPCProtobuf/CGRPCProtobuf.c
+++ b/Sources/CGRPCProtobuf/CGRPCProtobuf.c
@@ -1,18 +1,16 @@
-/*
- * Copyright 2025, gRPC Authors All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2025, gRPC Authors All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "CGRPCProtobuf.h"
 

--- a/Sources/CGRPCProtobuf/CGRPCProtobuf.c
+++ b/Sources/CGRPCProtobuf/CGRPCProtobuf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, gRPC Authors All rights reserved.
+ * Copyright 2025, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-private import CGRPCProtobuf
+#include "CGRPCProtobuf.h"
 
-internal enum Version {
-  /// The version string.
-  internal static var versionString: String {
-    String(cString: cgrprc_grpc_swift_protobuf_version())
-  }
+const char *cgrprc_grpc_swift_protobuf_version() {
+  return CGRPC_GRPC_SWIFT_PROTOBUF_VERSION;
 }

--- a/Sources/CGRPCProtobuf/include/CGRPCProtobuf.h
+++ b/Sources/CGRPCProtobuf/include/CGRPCProtobuf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, gRPC Authors All rights reserved.
+ * Copyright 2025, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-private import CGRPCProtobuf
+#ifndef CGRPC_PROTOBUF_H_
+#define CGRPC_PROTOBUF_H_
 
-internal enum Version {
-  /// The version string.
-  internal static var versionString: String {
-    String(cString: cgrprc_grpc_swift_protobuf_version())
-  }
-}
+const char *cgrprc_grpc_swift_protobuf_version();
+
+#endif  // CGRPC_PROTOBUF_H_

--- a/Sources/CGRPCProtobuf/include/CGRPCProtobuf.h
+++ b/Sources/CGRPCProtobuf/include/CGRPCProtobuf.h
@@ -1,18 +1,16 @@
-/*
- * Copyright 2025, gRPC Authors All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2025, gRPC Authors All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef CGRPC_PROTOBUF_H_
 #define CGRPC_PROTOBUF_H_

--- a/Sources/protoc-gen-grpc-swift/Version.swift
+++ b/Sources/protoc-gen-grpc-swift/Version.swift
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
+#if canImport(CGRPCProtobuf)
 private import CGRPCProtobuf
+#endif
 
 internal enum Version {
   /// The version string.
   internal static var versionString: String {
+    #if canImport(CGRPCProtobuf)
     String(cString: cgrprc_grpc_swift_protobuf_version())
+    #else
+    "unknown"
+    #endif
   }
 }


### PR DESCRIPTION
Motivation:

The version for the package included in protoc-gen-grpc-swift is updated manually and is currently incorrect. We can get the appropriate information from the context provided by SwiftPM.

Modifications:

- Add a C shim module which provides a version string from the package context

Result:

- Version string is kept up-to-date
- Resolves #60