### PR TITLE
Add deprecation warnings

### DIFF
--- a/Sources/GRPCProtobuf/Coding.swift
+++ b/Sources/GRPCProtobuf/Coding.swift
@@ -19,6 +19,7 @@ public import SwiftProtobuf
 
 /// Serializes a Protobuf message into a sequence of bytes.
 @available(gRPCSwiftProtobuf 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: GRPCCore.MessageSerializer {
   public init() {}
 
@@ -43,6 +44,7 @@ public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: GRPCCore.Messa
 
 /// Deserializes a sequence of bytes into a Protobuf message.
 @available(gRPCSwiftProtobuf 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: GRPCCore.MessageDeserializer {
   public init() {}
 

--- a/Sources/GRPCProtobuf/Errors/GoogleRPCStatus.swift
+++ b/Sources/GRPCProtobuf/Errors/GoogleRPCStatus.swift
@@ -36,6 +36,7 @@ public import SwiftProtobuf
 /// > the serialized bytes of a "google.rpc.Status" protocol buffers message containing the status
 /// > code, message, and details.
 @available(gRPCSwiftProtobuf 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct GoogleRPCStatus: Error, Hashable {
   /// A code representing the high-level domain of the error.
   public var code: RPCError.Code


### PR DESCRIPTION
Motivation:

gRPC Swift v2 has moved to a new repo, grpc-swift-2 and as a result this package has a new major version. That's not all that discoverable.

Modifications:

Deprecate commonly used high-level types with a link to a forums post explaining the move.

Result:

Users are notified about the move