### PR TITLE
Explicitly marked ContiguousBytesAdapter as non Sendable

### DIFF
--- a/Sources/GRPCProtobuf/ContiguousBytesAdapter.swift
+++ b/Sources/GRPCProtobuf/ContiguousBytesAdapter.swift
@@ -64,5 +64,5 @@ struct ContiguousBytesAdapter<
   }
 }
 
-@available(gRPCSwiftProtobuf 2.0, *)
+@available(gRPCSwiftProtobuf 2.1, *)
 extension ContiguousBytesAdapter: Sendable where Bytes: Sendable {}


### PR DESCRIPTION
Performed the necessary changes to enable compiler flag -require-explicit-sendable.