### PR TITLE
Fix some papercuts with the command plugin

### DIFF
--- a/Plugins/GRPCProtobufGeneratorCommand/CommandConfig.swift
+++ b/Plugins/GRPCProtobufGeneratorCommand/CommandConfig.swift
@@ -42,10 +42,8 @@ struct CommandConfig {
 }
 
 extension CommandConfig {
-  static func parse(
-    argumentExtractor argExtractor: inout ArgumentExtractor,
-    pluginWorkDirectory: URL
-  ) throws -> CommandConfig {
+  static func parse(args: [String]) throws -> CommandConfig {
+    var argExtractor = ArgumentExtractor(args)
     var config = CommandConfig.defaults
 
     for flag in OptionsAndFlags.allCases {
@@ -131,9 +129,7 @@ extension CommandConfig {
         config.common.protocPath = argExtractor.extractSingleOption(named: flag.rawValue)
 
       case .outputPath:
-        config.common.outputPath =
-          argExtractor.extractSingleOption(named: flag.rawValue)
-          ?? pluginWorkDirectory.absoluteStringNoScheme
+        config.common.outputPath = argExtractor.extractSingleOption(named: flag.rawValue) ?? "."
 
       case .verbose:
         let verbose = argExtractor.extractFlag(named: flag.rawValue)


### PR DESCRIPTION
Motivation:

The command plugin has a few rough edges which make it harder to use than it should.

Modifications:

- Check if help was requested before doing any other arg parsing. 
- Print help if no arguments were passed at all.
- Check all input files end in '.proto', if they don't it's likely an option was passed in the wrong place, so print a helpful error message.
- Change the default output path to be ".", i.e. the directory of the caller. Previously it was the plugin working directory which is buried in '.build' so it would appear as if nothing was generated.
- Improve the formatting of the error message if the protoc invocation failed. The error message now includes a better formatted command that the user can invoke directly. Remove the error description because it was always "NSTaskTermination" without any useful information attached.

Result:

Command plugin is a little easier to use.