### PR TITLE
Use relative path for input files to protoc

### DIFF
--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -68,7 +68,7 @@ func constructProtocGenSwiftArguments(
   protocArgs.append("--swift_opt=Visibility=\(config.accessLevel.rawValue)")
   protocArgs.append("--swift_opt=FileNaming=\(config.fileNaming.rawValue)")
   protocArgs.append("--swift_opt=UseAccessLevelOnImports=\(config.accessLevelOnImports)")
-  protocArgs.append(contentsOf: inputFiles.map { $0.absoluteStringNoScheme })
+  protocArgs.append(contentsOf: inputFiles.map { $0.relativePath })
 
   return protocArgs
 }
@@ -104,7 +104,7 @@ func constructProtocGenGRPCSwiftArguments(
   protocArgs.append("--grpc-swift_opt=Client=\(config.clients)")
   protocArgs.append("--grpc-swift_opt=FileNaming=\(config.fileNaming.rawValue)")
   protocArgs.append("--grpc-swift_opt=UseAccessLevelOnImports=\(config.accessLevelOnImports)")
-  protocArgs.append(contentsOf: inputFiles.map { $0.absoluteStringNoScheme })
+  protocArgs.append(contentsOf: inputFiles.map { $0.relativePath })
 
   return protocArgs
 }


### PR DESCRIPTION
Motivation:

protoc requires the import path (-I/--import-path) to be an exact prefix of the input files. The plugin currently uses the absolute path of a file for input paths without modifying the import path.

The result of this is that the user must always specify an absolute import path (because the default chosen by is protoc is ".").

Modifications:

- Use the relative path for input files (this will be whatever the user provides, which may be an absolute path) rather than the absolute path which will get the full absolute path even if the user specified "foo.proto" as input.

Result:

Users can do: swift package generate-grpc-code-from-protos foo.proto