### PR TITLE
Regenerate protos after update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.28.1"
+    from: "1.31.0"
   ),
 ]
 

--- a/Sources/GRPCProtobuf/Errors/Generated/code.pb.swift
+++ b/Sources/GRPCProtobuf/Errors/Generated/code.pb.swift
@@ -275,23 +275,5 @@ enum Google_Rpc_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension Google_Rpc_Code: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "OK"),
-    1: .same(proto: "CANCELLED"),
-    2: .same(proto: "UNKNOWN"),
-    3: .same(proto: "INVALID_ARGUMENT"),
-    4: .same(proto: "DEADLINE_EXCEEDED"),
-    5: .same(proto: "NOT_FOUND"),
-    6: .same(proto: "ALREADY_EXISTS"),
-    7: .same(proto: "PERMISSION_DENIED"),
-    8: .same(proto: "RESOURCE_EXHAUSTED"),
-    9: .same(proto: "FAILED_PRECONDITION"),
-    10: .same(proto: "ABORTED"),
-    11: .same(proto: "OUT_OF_RANGE"),
-    12: .same(proto: "UNIMPLEMENTED"),
-    13: .same(proto: "INTERNAL"),
-    14: .same(proto: "UNAVAILABLE"),
-    15: .same(proto: "DATA_LOSS"),
-    16: .same(proto: "UNAUTHENTICATED"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}CANCELLED\0\u{1}UNKNOWN\0\u{1}INVALID_ARGUMENT\0\u{1}DEADLINE_EXCEEDED\0\u{1}NOT_FOUND\0\u{1}ALREADY_EXISTS\0\u{1}PERMISSION_DENIED\0\u{1}RESOURCE_EXHAUSTED\0\u{1}FAILED_PRECONDITION\0\u{1}ABORTED\0\u{1}OUT_OF_RANGE\0\u{1}UNIMPLEMENTED\0\u{1}INTERNAL\0\u{1}UNAVAILABLE\0\u{1}DATA_LOSS\0\u{1}UNAUTHENTICATED\0")
 }

--- a/Sources/GRPCProtobuf/Errors/Generated/error_details.pb.swift
+++ b/Sources/GRPCProtobuf/Errors/Generated/error_details.pb.swift
@@ -517,11 +517,7 @@ fileprivate let _protobuf_package = "google.rpc"
 
 extension Google_Rpc_ErrorInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ErrorInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "reason"),
-    2: .same(proto: "domain"),
-    3: .same(proto: "metadata"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}reason\0\u{1}domain\0\u{1}metadata\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -561,9 +557,7 @@ extension Google_Rpc_ErrorInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Google_Rpc_RetryInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RetryInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "retry_delay"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}retry_delay\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -597,10 +591,7 @@ extension Google_Rpc_RetryInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Google_Rpc_DebugInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DebugInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "stack_entries"),
-    2: .same(proto: "detail"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stack_entries\0\u{1}detail\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -635,9 +626,7 @@ extension Google_Rpc_DebugInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Google_Rpc_QuotaFailure: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".QuotaFailure"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "violations"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}violations\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -667,16 +656,7 @@ extension Google_Rpc_QuotaFailure: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Google_Rpc_QuotaFailure.Violation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Google_Rpc_QuotaFailure.protoMessageName + ".Violation"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "subject"),
-    2: .same(proto: "description"),
-    3: .standard(proto: "api_service"),
-    4: .standard(proto: "quota_metric"),
-    5: .standard(proto: "quota_id"),
-    6: .standard(proto: "quota_dimensions"),
-    7: .standard(proto: "quota_value"),
-    8: .standard(proto: "future_quota_value"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}subject\0\u{1}description\0\u{3}api_service\0\u{3}quota_metric\0\u{3}quota_id\0\u{3}quota_dimensions\0\u{3}quota_value\0\u{3}future_quota_value\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -745,9 +725,7 @@ extension Google_Rpc_QuotaFailure.Violation: SwiftProtobuf.Message, SwiftProtobu
 
 extension Google_Rpc_PreconditionFailure: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PreconditionFailure"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "violations"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}violations\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -777,11 +755,7 @@ extension Google_Rpc_PreconditionFailure: SwiftProtobuf.Message, SwiftProtobuf._
 
 extension Google_Rpc_PreconditionFailure.Violation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Google_Rpc_PreconditionFailure.protoMessageName + ".Violation"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "type"),
-    2: .same(proto: "subject"),
-    3: .same(proto: "description"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}subject\0\u{1}description\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -821,9 +795,7 @@ extension Google_Rpc_PreconditionFailure.Violation: SwiftProtobuf.Message, Swift
 
 extension Google_Rpc_BadRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BadRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "field_violations"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}field_violations\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -853,12 +825,7 @@ extension Google_Rpc_BadRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
 
 extension Google_Rpc_BadRequest.FieldViolation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Google_Rpc_BadRequest.protoMessageName + ".FieldViolation"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "field"),
-    2: .same(proto: "description"),
-    3: .same(proto: "reason"),
-    4: .standard(proto: "localized_message"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}field\0\u{1}description\0\u{1}reason\0\u{3}localized_message\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -907,10 +874,7 @@ extension Google_Rpc_BadRequest.FieldViolation: SwiftProtobuf.Message, SwiftProt
 
 extension Google_Rpc_RequestInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RequestInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "request_id"),
-    2: .standard(proto: "serving_data"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}request_id\0\u{3}serving_data\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -945,12 +909,7 @@ extension Google_Rpc_RequestInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageI
 
 extension Google_Rpc_ResourceInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ResourceInfo"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "resource_type"),
-    2: .standard(proto: "resource_name"),
-    3: .same(proto: "owner"),
-    4: .same(proto: "description"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_type\0\u{3}resource_name\0\u{1}owner\0\u{1}description\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -995,9 +954,7 @@ extension Google_Rpc_ResourceInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
 
 extension Google_Rpc_Help: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Help"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "links"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}links\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1027,10 +984,7 @@ extension Google_Rpc_Help: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
 
 extension Google_Rpc_Help.Link: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Google_Rpc_Help.protoMessageName + ".Link"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "description"),
-    2: .same(proto: "url"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}description\0\u{1}url\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1065,10 +1019,7 @@ extension Google_Rpc_Help.Link: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Google_Rpc_LocalizedMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".LocalizedMessage"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "locale"),
-    2: .same(proto: "message"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}locale\0\u{1}message\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/GRPCProtobuf/Errors/Generated/status.pb.swift
+++ b/Sources/GRPCProtobuf/Errors/Generated/status.pb.swift
@@ -71,11 +71,7 @@ fileprivate let _protobuf_package = "google.rpc"
 
 extension Google_Rpc_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Status"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "code"),
-    2: .same(proto: "message"),
-    3: .same(proto: "details"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0\u{1}details\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/GRPCProtobufTests/Errors/Generated/error-service.pb.swift
+++ b/Tests/GRPCProtobufTests/Errors/Generated/error-service.pb.swift
@@ -51,9 +51,7 @@ struct ThrowInput: Sendable {
 
 extension ThrowInput: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = "ThrowInput"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "kind"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}kind\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {


### PR DESCRIPTION
Motivation:

swift-protobuf released a new version which modified generated code slightly. Our CI job for checking up-to-date generated code now fails.

Modifications:

- Update generated code

Result:

CI passes