### PR TITLE
Fix warnings in command plugin

### DIFF
--- a/Plugins/GRPCProtobufGeneratorCommand/CommandPluginError.swift
+++ b/Plugins/GRPCProtobufGeneratorCommand/CommandPluginError.swift
@@ -71,7 +71,7 @@ extension CommandPluginError: CustomStringConvertible {
       var iterator = arguments.makeIterator()
       var current = iterator.next()
       while let currentArg = current {
-        var nextArg = iterator.next()
+        let nextArg = iterator.next()
         defer { current = nextArg }
 
         if nextArg != nil {

--- a/Plugins/GRPCProtobufGeneratorCommand/Plugin.swift
+++ b/Plugins/GRPCProtobufGeneratorCommand/Plugin.swift
@@ -180,7 +180,7 @@ struct GRPCProtobufGeneratorCommandPlugin {
       } else if isDirectory.boolValue {
         dirs.append(file)
         // Do a deep traversal of the directory.
-        if var enumerator = fileManager.enumerator(atPath: file) {
+        if let enumerator = fileManager.enumerator(atPath: file) {
           while let path = enumerator.nextObject() as? String {
             if path.hasSuffix(".proto") {
               protos.append(path)
@@ -262,7 +262,6 @@ func executeProtocInvocation(
   } else {
     stdErr = nil
   }
-  let problem = "\(process.terminationReason):\(process.terminationStatus)"
   throw CommandPluginError.generationFailure(
     executable: executableURL.absoluteStringNoScheme,
     arguments: arguments,


### PR DESCRIPTION
Motivation:

The command plugin had a couple of warnings as vars weren't mutated.

Modifications:

- Change some vars to lets
- Remove an unused string

Result:

No warnings