### PR TITLE
Bump grpc-swift-2 depenendency requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift-2.git",
-    from: "2.0.0"
+    from: "2.2.1"
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -104,13 +104,13 @@ struct ProtobufCodeGeneratorTests {
 
         /// Namespace containing generated types for the "test.TestService" service.
         @available(\(expectedAvailability), *)
-        \(access) enum Test_TestService {
+        \(access) enum Test_TestService: Sendable {
           /// Service descriptor for the "test.TestService" service.
           \(access) static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "test.TestService")
           /// Namespace for method metadata.
-          \(access) enum Method {
+          \(access) enum Method: Sendable {
             /// Namespace for "Unary" metadata.
-            \(access) enum Unary {
+            \(access) enum Unary: Sendable {
               /// Request type for "Unary".
               \(access) typealias Input = Test_TestInput
               /// Response type for "Unary".
@@ -122,7 +122,7 @@ struct ProtobufCodeGeneratorTests {
               )
             }
             /// Namespace for "ClientStreaming" metadata.
-            \(access) enum ClientStreaming {
+            \(access) enum ClientStreaming: Sendable {
               /// Request type for "ClientStreaming".
               \(access) typealias Input = Test_TestInput
               /// Response type for "ClientStreaming".
@@ -134,7 +134,7 @@ struct ProtobufCodeGeneratorTests {
               )
             }
             /// Namespace for "ServerStreaming" metadata.
-            \(access) enum ServerStreaming {
+            \(access) enum ServerStreaming: Sendable {
               /// Request type for "ServerStreaming".
               \(access) typealias Input = Test_TestInput
               /// Response type for "ServerStreaming".
@@ -146,7 +146,7 @@ struct ProtobufCodeGeneratorTests {
               )
             }
             /// Namespace for "BidirectionalStreaming" metadata.
-            \(access) enum BidirectionalStreaming {
+            \(access) enum BidirectionalStreaming: Sendable {
               /// Request type for "BidirectionalStreaming".
               \(access) typealias Input = Test_TestInput
               /// Response type for "BidirectionalStreaming".

--- a/Tests/GRPCProtobufTests/Errors/Generated/error-service.grpc.swift
+++ b/Tests/GRPCProtobufTests/Errors/Generated/error-service.grpc.swift
@@ -31,13 +31,13 @@ internal import SwiftProtobuf
 
 /// Namespace containing generated types for the "ErrorService" service.
 @available(gRPCSwiftProtobuf 2.0, *)
-internal enum ErrorService {
+internal enum ErrorService: Sendable {
     /// Service descriptor for the "ErrorService" service.
     internal static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "ErrorService")
     /// Namespace for method metadata.
-    internal enum Method {
+    internal enum Method: Sendable {
         /// Namespace for "ThrowError" metadata.
-        internal enum ThrowError {
+        internal enum ThrowError: Sendable {
             /// Request type for "ThrowError".
             internal typealias Input = ThrowInput
             /// Response type for "ThrowError".


### PR DESCRIPTION
Motivation:

A recent release of grpc-swift-2 added a few sendable annotations to the generated code. The expected code in our tests is now incorrect so CI is failing.

Modifications:

- Bump version
- Update test expectations
- Regenerate

Result:

CI passes