### PR TITLE
Opt out of swift-protobuf default traits

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,8 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.38.0"
+    from: "1.38.0",
+    traits: []  // Opt-out of default traits to avoid pulling in full Foundation from `BinaryDelimitedStreams`
   ),
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,8 @@ let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
     from: "1.38.0",
-    traits: []  // Opt-out of default traits to avoid pulling in full Foundation from `BinaryDelimitedStreams`
+    // Opt-out of default traits to avoid pulling in full Foundation from `BinaryDelimitedStreams`
+    traits: []
   ),
 ]
 


### PR DESCRIPTION
swift-protobuf enables two traits by default: BinaryDelimitedStreams and FieldMaskUtilities which grpc-swift-protobuf does not use.

BinaryDelimitedStreams gates BinaryDelimited.swift, the only file in the SwiftProtobuf target that imports full Foundation (for InputStream/ OutputStream) rather than FoundationEssentials. Because SE-0450 composes traits by union across the dependency graph, leaving the default in place forces every downstream package to link full Foundation, defeating FoundationEssentials-only builds.

Pass traits: [] so this edge no longer contributes the defaults.

Addresses: #101 